### PR TITLE
refactor: expose container

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -32,8 +32,10 @@ export class Storage implements ContextStorage<any>{
 export class Context implements BaseContext {
   public input: BaseInput = new Input();
   public output: BaseOutput = new Output();
+
+  // 不建议对外使用
+  public container: ExecutionContainer;
   private storageMap = new Map<string, ContextStorage<any>>();
-  protected container: ExecutionContainer;
 
   constructor(input?: Input, output?: Output, opts?: ContextInitOptions) {
     this.input = input ?? this.input;


### PR DESCRIPTION
Core 中的实际使用发现在现行模式下，很难避免使用 ctx.container.set，考虑先暴露出来，后期再考虑如何对最上层加保护