### PR TITLE
chore: remove duplicate

### DIFF
--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -24,7 +24,6 @@ describe('test/pipeline.test.ts', () => {
 
     const ctx = new Context();
     await pipeline.run(ctx);
-    await pipeline.run(ctx);
 
     const { data } = ctx.output;
     assert(data.get('responseValue') === 1);


### PR DESCRIPTION
```ts
await pipeline.run(ctx);
```
不需要 run 两次？